### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/{{cookiecutter.repo_name}}/README.rst
+++ b/{{cookiecutter.repo_name}}/README.rst
@@ -36,7 +36,7 @@ As a developer, to create a working directory for this project, call these comma
     invoke build check
 
 You might also need to follow some
-`setup procedures <https://py-generic-project.readthedocs.org/en/latest/installing.html#quick-setup>`_
+`setup procedures <https://py-generic-project.readthedocs.io/en/latest/installing.html#quick-setup>`_
 to make the necessary basic commands available on *Linux*, *Mac OS X*, and *Windows*.
 
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.